### PR TITLE
fix: do not use local .eslintrc files

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -42,6 +42,7 @@ const cli = new CLIEngine({
   fix: Boolean(commander.format),
   ignorePattern: config.ignore,
   cache: true,
+  useEslintrc: false,
   rules
 });
 


### PR DESCRIPTION
Local `.eslintrc` files are currently being used. For various reasons we turn this off for babel, and we should do the same for `eslint` as it can cause all kinds of strange issues. If anyone has an issue with the rules or needs something specific we should implement it in this repo or `eslint-config-videojs`