### PR TITLE
fix: ignore node modules

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -36,6 +36,9 @@ if (config.jsdoc === false) {
   rules['jsdoc/newline-after-description'] = 'off';
 }
 
+config.ignore = config.ignore || [];
+config.ignore.push('node_modules');
+
 const cli = new CLIEngine({
   cwd: process.cwd(),
   baseConfig: require(path.join(__dirname, 'eslintrc.json')),


### PR DESCRIPTION
It seems like node_modules are no longer ignored by default in eslint, we should ignore them again.