### PR TITLE
fix: remove .eslintcache on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "npm run lint",
     "preversion": "npm test",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",
-    "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s"
+    "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s",
+    "postinstall": "node remove-cache.js"
   },
   "lint-staged": {
     "*.js": [

--- a/remove-cache.js
+++ b/remove-cache.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const cache = path.join(process.env.INIT_CWD, '.eslintcache');
+const cache = path.join(process.cwd(), '.eslintcache');
 
 try {
   fs.unlinkSync(cache);

--- a/remove-cache.js
+++ b/remove-cache.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+const cache = path.join(process.env.INIT_CWD, '.eslintcache');
+
+try {
+  fs.unlinkSync(cache);
+  console.log('removed .eslintcache');
+} catch (e) {
+  // file doesn't exist or we cannot delete.
+}


### PR DESCRIPTION
This will make linting post install slower but a reinstall will fix issuse with eslintcache which is more beneficial. 