### PR TITLE
fix: always remove cache using root directory

### DIFF
--- a/remove-cache.js
+++ b/remove-cache.js
@@ -1,12 +1,14 @@
 /* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
-
-const cache = path.join(process.cwd(), '.eslintcache');
+const findRoot = require('find-root');
 
 try {
-  fs.unlinkSync(cache);
-  console.log('removed .eslintcache');
+  const root = findRoot(process.env.INIT_CWD || process.cwd());
+  const cachePath = path.join(root, '.eslintcache');
+
+  fs.unlinkSync(cachePath);
+  console.log(`removed ${cachePath}`);
 } catch (e) {
   // file doesn't exist or we cannot delete.
 }


### PR DESCRIPTION
The previous pr doesn't really work as npm moves process.cwd to the install directory of the current package ie : `node_modules/videojs-standard/` so we were only removing `node_modules/videojs-standard/.eslintcache` :doh: .
I should have pushed back more on using INIT_CWD but falling back to process.cwd() and we should use find-root to make sure that we always look in the project root directory.